### PR TITLE
fix: jsvectormap css path import issue with new version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "apexcharts": "^3.45.2",
         "flatpickr": "^4.6.13",
-        "jsvectormap": "^1.5.3",
+        "jsvectormap": "^1.6.0",
         "next": "^14.1.4",
         "react": "^18",
         "react-apexcharts": "^1.4.1",
@@ -2436,7 +2436,8 @@
     "node_modules/flatpickr": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
-      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "license": "MIT"
     },
     "node_modules/flatted": {
       "version": "3.2.9",
@@ -3321,9 +3322,10 @@
       }
     },
     "node_modules/jsvectormap": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/jsvectormap/-/jsvectormap-1.5.3.tgz",
-      "integrity": "sha512-HStTEhZEVr8t3t6juApO603nr1y54K/wjcdOvgGtvpE1etZ9Isg/sLdqh7OX4+RJ8srdP7WiBoTV/93aMqhLhw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jsvectormap/-/jsvectormap-1.6.0.tgz",
+      "integrity": "sha512-4b/v4GWqiggHGN+CBOJBhIdpSGLY6wVetmMKiOlQ7oVM1PIzsLlSBJDMQd9ycLk6Rmzg4aFua35QDrk5HPb1YQ==",
+      "license": "MIT"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "apexcharts": "^3.45.2",
     "flatpickr": "^4.6.13",
-    "jsvectormap": "^1.5.3",
+    "jsvectormap": "^1.6.0",
     "next": "^14.1.4",
     "react": "^18",
     "react-apexcharts": "^1.4.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "jsvectormap/dist/css/jsvectormap.css";
+import "jsvectormap/dist/jsvectormap.css";
 import "flatpickr/dist/flatpickr.min.css";
 import "@/css/satoshi.css";
 import "@/css/style.css";


### PR DESCRIPTION
In newer versions of jsvectormap, they do not use the CSS folder anymore. 
So the import path is changed 
From -  
import "jsvectormap/dist/css/jsvectormap.css";
To -
import "jsvectormap/dist/jsvectormap.css";